### PR TITLE
PLAT-11574-preprod - use basic dyno size

### DIFF
--- a/app.json
+++ b/app.json
@@ -25,7 +25,7 @@
   "formation": {
     "web": {
       "quantity": 1,
-      "size": "free"
+      "size": "basic"
     }
   }
 }


### PR DESCRIPTION
Use basic dyno size instead of free. Using free causes a failure in scaling dynos for Heroku teams.